### PR TITLE
Sorting edition articles by tags

### DIFF
--- a/Sources/App/Controllers/ArticlesController.swift
+++ b/Sources/App/Controllers/ArticlesController.swift
@@ -52,14 +52,19 @@ extension ArticlesController {
         let articles = edition
             .flatMap(to: [Article].self) {
                 try $0.articles.query(on: req)
-                    .sort(\.title)
                     .all()
         }
         
         return edition
             .and(articles)
             .map(to: EditionDetailsOutput.self) { edition, articles in
-                return EditionDetailsOutput(edition: edition, articles: articles)
+                let sortedArticles = articles.sorted(by: { (left, right) -> Bool in
+                    let leftFlatTags = left.tags.joined()
+                    let rightFlatTags = right.tags.joined()
+                    return leftFlatTags < rightFlatTags || (left.title < right.title && leftFlatTags == rightFlatTags)
+                })
+                
+                return EditionDetailsOutput(edition: edition, articles: sortedArticles)
         }
     }
     

--- a/Sources/App/Controllers/ArticlesController.swift
+++ b/Sources/App/Controllers/ArticlesController.swift
@@ -61,7 +61,7 @@ extension ArticlesController {
                 let sortedArticles = articles.sorted(by: { (left, right) -> Bool in
                     let leftFlatTags = left.tags.joined()
                     let rightFlatTags = right.tags.joined()
-                    return leftFlatTags < rightFlatTags || (left.title < right.title && leftFlatTags == rightFlatTags)
+                    return leftFlatTags < rightFlatTags || (leftFlatTags == rightFlatTags && left.title < right.title)
                 })
                 
                 return EditionDetailsOutput(edition: edition, articles: sortedArticles)


### PR DESCRIPTION
Issue Reference: https://github.com/pedrommcarrasco/CocoaHub.server/issues/1

Updated the sorting of articles within an edition by tags and, if multiple articles have the same tags, sorting those by title.