### PR TITLE
Sort tags on model create/update

### DIFF
--- a/Sources/App/Classes/Models/Tags.swift
+++ b/Sources/App/Classes/Models/Tags.swift
@@ -18,23 +18,18 @@ enum TagType {
 struct Tags {
     
     static func allowedTags(from tags: [String], of type: TagType) -> [String] {
-        switch type {
-        case .event:
-            return tags.compactMap {
-                guard let event = Event(rawValue: $0) else { return nil }
-                return event.rawValue
+        return tags
+            .compactMap {
+                switch type {
+                case .event:
+                    return Event(rawValue: $0)?.rawValue
+                case .new:
+                    return New(rawValue: $0)?.rawValue
+                case .article:
+                    return Article(rawValue: $0)?.rawValue
+                }
             }
-        case .new:
-            return tags.compactMap {
-                guard let new = New(rawValue: $0) else { return nil }
-                return new.rawValue
-            }
-        case .article:
-            return tags.compactMap {
-                guard let article = Article(rawValue: $0) else { return nil }
-                return article.rawValue
-            }
-        }
+            .sorted()
     }
 }
 

--- a/Sources/App/Models/Database/Article.swift
+++ b/Sources/App/Models/Database/Article.swift
@@ -32,7 +32,17 @@ final class Article {
 }
 
 // MARK: - MySQLModel
-extension Article: MySQLModel {}
+extension Article: MySQLModel {
+    func willCreate(on conn: MySQLConnection) throws -> EventLoopFuture<Article> {
+        tags = Tags.allowedTags(from: tags, of: .article)
+        return Future.map(on: conn) { self }
+    }
+    
+    func willUpdate(on conn: MySQLConnection) throws -> EventLoopFuture<Article> {
+        tags = Tags.allowedTags(from: tags, of: .article)
+        return Future.map(on: conn) { self }
+    }
+}
 
 // MARK: - Content
 extension Article: Content {}

--- a/Sources/App/Models/Database/Event.swift
+++ b/Sources/App/Models/Database/Event.swift
@@ -37,7 +37,17 @@ final class Event {
 }
 
 // MARK: - MySQLModel
-extension Event: MySQLModel {}
+extension Event: MySQLModel {
+    func willCreate(on conn: MySQLConnection) throws -> EventLoopFuture<Event> {
+        tags = Tags.allowedTags(from: tags, of: .event)
+        return Future.map(on: conn) { self }
+    }
+    
+    func willUpdate(on conn: MySQLConnection) throws -> EventLoopFuture<Event> {
+        tags = Tags.allowedTags(from: tags, of: .event)
+        return Future.map(on: conn) { self }
+    }
+}
 
 // MARK: - Content
 extension Event: Content {}

--- a/Sources/App/Models/Database/New.swift
+++ b/Sources/App/Models/Database/New.swift
@@ -33,7 +33,17 @@ final class New {
 }
 
 // MARK: - MySQLModel
-extension New: MySQLModel {}
+extension New: MySQLModel {
+    func willCreate(on conn: MySQLConnection) throws -> EventLoopFuture<New> {
+        tags = Tags.allowedTags(from: tags, of: .new)
+        return Future.map(on: conn) { self }
+    }
+    
+    func willUpdate(on conn: MySQLConnection) throws -> EventLoopFuture<New> {
+        tags = Tags.allowedTags(from: tags, of: .new)
+        return Future.map(on: conn) { self }
+    }
+}
 
 // MARK: - Content
 extension New: Content {}


### PR DESCRIPTION
Issue Reference: https://github.com/pedrommcarrasco/CocoaHub.server/issues/3

Updated `Article`, `Event`, and `New` models to validate/sort tags on create/update. 